### PR TITLE
refactoring clock functionality to be more performant

### DIFF
--- a/injectors/clockInjector.js
+++ b/injectors/clockInjector.js
@@ -1,20 +1,26 @@
-console.log("[STADIA+] Injecting Clock");
 
-window.addEventListener("load", () => {
+console.log('[STADIA+] Injecting Clock');
+
+window.addEventListener('load', () => {
+	const container = document.querySelector('.hxhAyf');
+    const el = document.createElement('span');
+
+    let time;
+
+    el.id = 'sidebar_clock';
+    el.classList.add('stadiaplus_clock');
+    container.prepend(el);
+
+    function updateClock() {
+        el.innerHTML = time;
+    }
+
     setInterval(() => {
-        let container = document.querySelector(".hxhAyf");
-        let clock = document.querySelector("#sidebar_clock");
-        if(clock) {
-            clock.innerHTML = new Date().toLocaleTimeString();
-            return;
+        if (!container) {
+          return;
         }
-        if(!container) {
-            return;
-        }
-        let el = document.createElement("span");
-        el.id = "sidebar_clock";
-        el.innerHTML = new Date().toLocaleTimeString();
-        el.classList.add("stadiaplus_clock");
-        container.prepend(el);  
+        time = new Date().toLocaleTimeString();
+
+        window.requestAnimationFrame(updateClock);
     }, 1000);
 });


### PR DESCRIPTION
refactoring clock functionality to be more performant. current logic is doing querying, element creation and date creation every 1000ms. this changes the logic to pre-query elements, store references upfront and schedule time updates only when a render occurs.

