### PR TITLE
Fix for Network monitor stops working when a controller is linked.

### DIFF
--- a/src/MonitorRunnable.js
+++ b/src/MonitorRunnable.js
@@ -158,9 +158,9 @@ const MonitorRunnable = function () {
     this.stats = [];
     this.update = function () {
         if (this.peerConnections.length > 1) {
-            const index = this.peerConnections.length - 1;
-
-            this.peerConnections[index].getStats().then((_stats) => {
+          const removedClosed = this.peerConnections.filter(x => x.connectionState == "connected");
+          
+          removedClosed[1].getStats().then((_stats) => {
                 this.stats = Array.from(_stats);
 
                 const RTCInboundRTPVideoStream = this.getStat((stat) =>

--- a/src/MonitorRunnable.js
+++ b/src/MonitorRunnable.js
@@ -158,9 +158,9 @@ const MonitorRunnable = function () {
     this.stats = [];
     this.update = function () {
         if (this.peerConnections.length > 1) {
-          const removedClosed = this.peerConnections.filter(x => x.connectionState == "connected");
-          
-          removedClosed[1].getStats().then((_stats) => {
+          const openConnections = this.peerConnections.filter(x => x.connectionState == "connected");
+
+          openConnections[1].getStats().then((_stats) => {
                 this.stats = Array.from(_stats);
 
                 const RTCInboundRTPVideoStream = this.getStat((stat) =>


### PR DESCRIPTION
https://github.com/Mafrans/StadiaPlus/issues/76

When a controller is added a new peer connection is added, this caused the last connection to be without the data needed or a closed connection.
By removing closed connections, the second connection contains the data for Network monitoring. 