### PR TITLE
Library background animations using transform

### DIFF
--- a/src/components/LibraryFilter.ts
+++ b/src/components/LibraryFilter.ts
@@ -185,7 +185,7 @@ export class LibraryFilter extends Component {
                 });
 
                 this.gameContainer?.appendChild(tile);
-                tile.style.backgroundSize = `auto ${tile.offsetHeight + 16}px`; // Add arbitrary magic number to make sure there aren't visible borders
+                //tile.style.backgroundSize = `auto ${tile.offsetHeight + 16}px`; // Removed due to new animation system
 
                 const listGame = $el('div')
                     .class({ 'stadiaplus_libraryfilter-listgame': true })

--- a/src/components/styles/LibraryFilter.scss
+++ b/src/components/styles/LibraryFilter.scss
@@ -339,6 +339,7 @@
         .stadiaplus_libraryfilter-game {
             display: inline-flex;
             position: relative;
+            overflow: hidden;
 
             width: calc(25% - 1.5rem);
             height: 32vh;
@@ -349,10 +350,7 @@
 
             box-shadow: 0 0.125rem 0.75rem rgba(0,0,0,0.32), 0 0.0625rem 0.375rem rgba(0,0,0,0.18);
 
-            background-color: rgba(255, 255, 255, 0.06);
-            background-position: center center;
-            background-size: 210%;
-            transition: background-size 0.5s cubic-bezier(0, 0, 0.2, 1), transform 0.2s ease-out;
+            transition: transform 0.2s ease-out;
             transform: scale(1);
             cursor: pointer;
 
@@ -362,6 +360,19 @@
 
             &.hidden {
                 display: none;
+            }
+
+            .tile-background {
+                position: absolute;
+                top: -1vw;
+                left: -1vw;
+                right: -1vw;
+                bottom: -1vw;
+                background-position: center center;
+                background-size: cover;
+                transform: scale(1);
+                z-index: -1;
+                transition: transform 0.5s cubic-bezier(0, 0, 0.2, 1);
             }
 
             .play-button {
@@ -407,6 +418,10 @@
                 &::before,
                 .content {
                     opacity: 0;
+                }
+
+                .tile-background {
+                    transform: scale(1.3);
                 }
 
                 .play-button {

--- a/src/models/LibraryGame.ts
+++ b/src/models/LibraryGame.ts
@@ -42,6 +42,13 @@ export class LibraryGame {
             .class({ 'stadiaplus_libraryfilter-game': true })
             .attr({ 'data-uuid': this.uuid, 'tab-index': 0 })
             .child(
+                $el('div')
+                    .class({ 'tile-background': true })
+                    .css({
+                        'background-image': this.img !== '' ? `url(${this.img})` : '',
+                    }),
+            )
+            .child(
                 $el('img')
                     .class({ 'play-button': true })
                     .attr({
@@ -61,8 +68,7 @@ export class LibraryGame {
                     .child($el('h6').text(this.name)),
             )
             .css({
-                display: this.visible ? '' : 'none',
-                'background-image': this.img !== '' ? `url(${this.img})` : '',
+                display: this.visible ? '' : 'none'
             });
 
         const moreDropdown = this.getMoreDropdown();


### PR DESCRIPTION
The game tile backgrounds in the library are now set to use the css `transform` property on a child element in order to better adapt to various tile sizes.

This way, the `background-size` property can be set to `cover` while still allowing for a smooth "zoom-in" animation.

The `16px` extra padding that was used (referenced as a "magic number" in the code comments) has now been replaced by a `1vw` margin to scale properly with the window size (and the background image as a result).