### PR TITLE
Square images

### DIFF
--- a/src/StadiaGameDB.ts
+++ b/src/StadiaGameDB.ts
@@ -46,7 +46,7 @@ export namespace StadiaGameDB {
                 const game: StadiaGameDB.Game = {
                     uuid,
                     storeId: /https:\/\/stadia.google.com\/store\/details\/([0-9a-z/]+)/g.exec(entry[0])?.[1],
-                    img: `https://stadiagamedb.com/images/posters/webp/${imgName}.webp`,
+                    img: `https://stadiagamedb.com/images/posters/webp/square/${imgName}.webp`,
                     name: entry[1],
                     tags: entry[2]
                         .split(', ')

--- a/src/lang/fr-FR.json
+++ b/src/lang/fr-FR.json
@@ -107,7 +107,7 @@
     },
     "ratings": {
         "name": "Évaluations",
-        "source-name": "Metacritic"
+        "source-name": "Métacritic"
     },
     "store-filter": {
         "name": "Filtre du magasin"


### PR DESCRIPTION
StadiaGamesDB now includes the "square" image variants as discussed [here](https://github.com/nilicule/StadiaGameDB/issues/72).

These should be more appropriate to the current display format of the Stadia+ library.