### PR TITLE
Responsive Layout

### DIFF
--- a/src/components/LibraryFilter.ts
+++ b/src/components/LibraryFilter.ts
@@ -375,12 +375,12 @@ export class LibraryFilter extends Component {
         const root = $sel(
             this.renderer.querySelector('.f2pfBf') as HTMLElement,
         );
-        root.id(this.id);
+        root.id( this.id )
+            .class({'stadiaplus_libraryfilter-wrapper': true});
         const barContainer = root.$sel('.lEPylf:first-child');
 
         const gameContainer = root
-            .$sel('.lEPylf:last-child')
-            ?.css({ padding: '0' });
+            .$sel('.lEPylf:last-child');
         if (root === null || barContainer === null) return;
 
         const orderDropdown = this.getOrderDropdown();
@@ -389,7 +389,7 @@ export class LibraryFilter extends Component {
             .class({ 'stadiaplus_libraryfilter-bar': true })
             .child(
                 $el('div')
-                    .css({ display: 'flex', width: '300px' })
+                    .class({ 'bar-dropdowns': true })
                     .child(
                         $el('div')
                             .class({ 'bar-item': true })
@@ -459,6 +459,44 @@ export class LibraryFilter extends Component {
                             )
                             .child(visibleDropdown),
                     ),
+            )
+            .child(
+                $el('div')
+                    .class({
+                        'bar-item': true,
+                        'searchcolumn-toggle': true
+                    })
+                    .child(
+                        $el('button')
+                            .class({ 'stadiaplus_libraryfilter-button': true })
+                            .event({
+                                click: (event) => {
+                                    this.renderer?.querySelectorAll(
+                                        '.stadiaplus_libraryfilter-wrapper'
+                                    ).forEach((element) => {
+                                        element.classList.toggle( 'searchcolumn-shown' );
+                                    });
+
+                                    event.stopPropagation();
+                                },
+                            })
+                            .child(
+                                $el('i')
+                                    .class({
+                                        'material-icons-extended': true,
+                                        'searchcolumn-toggle-icon-search': true
+                                    })
+                                    .text('search')
+                            )
+                            .child(
+                                $el('i')
+                                    .class({
+                                        'material-icons-extended': true,
+                                        'searchcolumn-toggle-icon-back': true
+                                    })
+                                    .text('arrow_back')
+                            )
+                    )
             )
             .child(
                 $el('div')
@@ -720,6 +758,11 @@ export class LibraryFilter extends Component {
                 'stadiaplus_libraryfilter-button': true,
                 active: localStorage.getItem('autoUpdate') === 'true',
             })
+            .child(
+                $el('i')
+                    .class({ 'material-icons-extended': true })
+                    .text('update_disabled'),
+            )
             .child(
                 $el('i')
                     .class({ 'material-icons-extended': true })

--- a/src/components/LibraryFilter.ts
+++ b/src/components/LibraryFilter.ts
@@ -375,7 +375,7 @@ export class LibraryFilter extends Component {
         const root = $sel(
             this.renderer.querySelector('.f2pfBf') as HTMLElement,
         );
-        root.id( this.id )
+        root.id(this.id)
             .class({'stadiaplus_libraryfilter-wrapper': true});
         const barContainer = root.$sel('.lEPylf:first-child');
 
@@ -468,14 +468,15 @@ export class LibraryFilter extends Component {
                     })
                     .child(
                         $el('button')
-                            .class({ 'stadiaplus_libraryfilter-button': true })
+                            .class({'stadiaplus_libraryfilter-button': true})
                             .event({
                                 click: (event) => {
-                                    this.renderer?.querySelectorAll(
-                                        '.stadiaplus_libraryfilter-wrapper'
-                                    ).forEach((element) => {
-                                        element.classList.toggle( 'searchcolumn-shown' );
-                                    });
+                                    this.renderer
+                                        ?.querySelectorAll(
+                                            '.stadiaplus_libraryfilter-wrapper'
+                                        ).forEach((element) => {
+                                            element.classList.toggle( 'searchcolumn-shown' );
+                                        });
 
                                     event.stopPropagation();
                                 },
@@ -486,7 +487,7 @@ export class LibraryFilter extends Component {
                                         'material-icons-extended': true,
                                         'searchcolumn-toggle-icon-search': true
                                     })
-                                    .text('search')
+                                    .text('search'),
                             )
                             .child(
                                 $el('i')
@@ -494,9 +495,9 @@ export class LibraryFilter extends Component {
                                         'material-icons-extended': true,
                                         'searchcolumn-toggle-icon-back': true
                                     })
-                                    .text('arrow_back')
-                            )
-                    )
+                                    .text('arrow_back'),
+                            ),
+                    ),
             )
             .child(
                 $el('div')

--- a/src/components/styles/LibraryFilter.scss
+++ b/src/components/styles/LibraryFilter.scss
@@ -143,11 +143,11 @@ $break-uhd: 2560px;
         pointer-events: all;
         width: max-content;
 
-        > h6 {
+        >h6 {
             display: inline-block;
             pointer-events: none;
-
-            ~ .material-icons-extended {
+            
+            ~.material-icons-extended {
                 position: absolute;
                 vertical-align: text-bottom;
             }
@@ -419,6 +419,8 @@ $break-uhd: 2560px;
         display: inline-flex;
         position: relative;
 
+        margin-bottom: 1rem;
+
         box-shadow: 0 0.125rem 0.75rem rgba(0,0,0,0.32), 0 0.0625rem 0.375rem rgba(0,0,0,0.18);
 
         transition: transform 0.2s ease-out;
@@ -444,6 +446,15 @@ $break-uhd: 2560px;
             grid-column: span 2/span 2;
         }
 
+        &:hover {
+            z-index: 98;
+        }
+
+        >.GqLi4d {
+            width: 100%;
+            height: 100%;
+        }
+
         >.Llx2qd {
             ~.more-icon {
                 display: none;
@@ -467,7 +478,7 @@ $break-uhd: 2560px;
             width: 40px;
             height: 40px;
             margin: 0.25rem;
-            z-index: 2;
+            z-index: 99;
             border-radius: 50%;
 
             &:hover {

--- a/src/components/styles/LibraryFilter.scss
+++ b/src/components/styles/LibraryFilter.scss
@@ -1,16 +1,10 @@
-.iadg4b {
-    margin: 0 auto;
-
-    @media screen and (min-width: 1200px) {
-        max-width: 1150px;
-    }
-    @media screen and (min-width: 1600px) {
-        max-width: 1500px;
-    }
-    @media screen and (min-width: 1800px) {
-        max-width: 1650px;
-    }
-}
+$break-stadia-mobile: 416px;
+$break-stadia-sd: 640px;
+$break-s: 880px;
+$break-stadia-hd: 1024px;
+$break-m: 1440px;
+$break-stadia-fhd: 1920px;
+$break-uhd: 2560px;
 
 .stadiaplus_libraryfilter-captures {
     position: absolute;
@@ -128,25 +122,57 @@
 }
 
 .stadiaplus_libraryfilter-bar {
-    margin-top: 2rem;
-    height: 100px;
+    padding: 0 0 1.5rem;
     display: flex;
     align-items: center;
+
+    .bar-dropdowns {
+        display: flex;
+        width: 300px;
+        transition: margin-left 0.2s ease-out, padding 0.2s ease-out;
+
+        @media screen and (max-width: $break-stadia-hd - 1) {
+            margin-left: -300px;
+        }
+    }
 
     .bar-item {
         margin-right: 2rem;
         position: relative;
         cursor: pointer;
         pointer-events: all;
-        width: max-content; 
+        width: max-content;
 
-        >h6 {
+        > h6 {
             display: inline-block;
             pointer-events: none;
-            
-            ~.material-icons-extended {
+
+            ~ .material-icons-extended {
                 position: absolute;
                 vertical-align: text-bottom;
+            }
+        }
+
+        &.searchcolumn-toggle {
+            margin: 0.75rem;
+            transition: margin-left 0.2s ease-out;
+
+            @media screen and (min-width: $break-stadia-hd) {
+                display: none;
+            }
+
+            .material-icons-extended {
+                padding-right: 0;
+                transition: transform 0.2s ease-out 0.2s;
+
+                &.searchcolumn-toggle-icon-search {
+                    transition-delay: 0.4s;
+                }
+
+                &.searchcolumn-toggle-icon-back {
+                    margin-left: -1em;
+                    transform: rotateY(90deg);
+                }
             }
         }
     }
@@ -162,7 +188,6 @@
     border: none;
     font-size: 18px;
     padding: 0.75rem 1.5rem;
-    margin-left: 1.5rem;
     color: #ffffff;
 
     &.hold {
@@ -173,11 +198,33 @@
     &.active {
         transition: background 0.06s ease-out;
         background: #FA4821;
+
+        .material-icons-extended {
+            transform: rotateY(-90deg);
+
+            transition-delay: 0s;
+
+            + .material-icons-extended {
+                transform: rotateY(0deg);
+
+                transition-delay: 0.2s;
+            }
+        }
     }
 
     .material-icons-extended {
         font-size: 20px;
         padding-right: 0.5rem;
+        line-height: 20px;
+
+        transition: transform 0.2s ease-out 0.2s;
+
+        + .material-icons-extended {
+            margin-left: calc(-1em - 0.5rem);
+            transform: rotateY(90deg);
+
+            transition-delay: 0s;
+        }
     }
 }
 
@@ -269,7 +316,21 @@
 
 .stadiaplus_libraryfilter {
     pointer-events: initial;
-    display: flex !important;
+    
+    display: flex;
+
+    &.lEPylf {
+        display: flex;
+
+        @media screen and (max-width: $break-stadia-hd - 1) {
+            grid-gap: 0;
+        }
+    }
+
+    >.lEPylf {
+        padding-left: 0;
+        padding-right: 0;
+    }
 
     .stadiaplus_libraryfilter-searchcolumn {
         width: 300px;
@@ -281,6 +342,14 @@
 
         white-space: nowrap;
         overflow: hidden;
+
+        @media screen and (max-width: $break-stadia-hd - 1) {
+            position: absolute;
+            z-index: 1;
+            left: calc(-300px - 0.75rem);
+            transition: left 0.2s ease-out, opacity 0.4s ease-out 0.2s;
+            opacity: 0;
+        }
 
         .stadiaplus_libraryfilter-searchcolumn-bar {
             display: flex;
@@ -347,12 +416,7 @@
         display: inline-flex;
         position: relative;
         overflow: hidden;
-
-        width: calc(25% - 1.5rem);
-        height: 32vh;
         
-        margin-left: 1.5rem;
-        margin-bottom: 1.5rem;
         border-radius: 0.5rem;
 
         box-shadow: 0 0.125rem 0.75rem rgba(0,0,0,0.32), 0 0.0625rem 0.375rem rgba(0,0,0,0.18);
@@ -360,6 +424,25 @@
         transition: transform 0.2s ease-out;
         transform: scale(1);
         cursor: pointer;
+        
+        @media screen and (min-width: $break-stadia-sd) {
+            grid-column: span 6/span 6;
+        }
+        @media screen and (min-width: $break-s) {
+            grid-column: span 4/span 4;
+        }
+        @media screen and (min-width: $break-stadia-hd) {
+            grid-column: span 6/span 6;
+        }
+        @media screen and (min-width: $break-m) {
+            grid-column: span 4/span 4;
+        }
+        @media screen and (min-width: $break-stadia-fhd) {
+            grid-column: span 3/span 3;
+        }
+        @media screen and (min-width: $break-uhd) {
+            grid-column: span 2/span 2;
+        }
 
         &:nth-last-child(-1n+4) {
             margin-bottom: 0;
@@ -436,6 +519,7 @@
                 top: 50%;
                 left: 50%;
                 transform: translate(-50%, -50%);
+                text-shadow: 0 0 0.25rem #000;
             }
         }
 
@@ -503,6 +587,47 @@
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
+            }
+        }
+    }
+}
+
+
+.stadiaplus_libraryfilter-wrapper {
+
+    &.searchcolumn-shown {
+        @media screen and (max-width: $break-stadia-hd - 1) {
+
+            .stadiaplus_libraryfilter-searchcolumn {
+                left: 0.75rem;
+
+                opacity: 1;
+                
+                transition: left 0.2s ease-out, opacity 0.1s ease;
+            }
+
+            .stadiaplus_libraryfilter-bar {
+                .bar-dropdowns {
+                    margin-left: 0;
+                    padding-right: calc(-5.25rem - 1.2em);
+                }
+                .searchcolumn-toggle {
+                    margin-left: calc(-5.25rem - 1.2em);
+
+                    .material-icons-extended
+                    {
+                        &.searchcolumn-toggle-icon-search
+                        {
+                            transform: rotateY(-90deg);
+                            transition-delay: 0.2s;
+                        }
+                        &.searchcolumn-toggle-icon-back
+                        {
+                            transform: rotateY(0deg);
+                            transition-delay: 0.4s;
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Replaces #140 to function with the new Stadia UI layout.

This modification brings 2 main things:

1. The library is now more responsive, with a number of columns that changes dynamically based on the window width (in px). This is based on css @media queries set to follow the same intervals as the default Stadia page's css (+ some more intervals to keep things clean).
2. The main "search" panel at the left of the library is now masked by default on lower resolutions (<1024px) with a button to reveal it placed to the left of the "Auto Update" button.

*Note: This updated version uses the css `grid` system to ensure the responsiveness better follows Stadia's layout system.*