### PR TITLE
Library Dropdown Fix

### DIFF
--- a/src/components/styles/LibraryFilter.scss
+++ b/src/components/styles/LibraryFilter.scss
@@ -249,13 +249,14 @@
     &.flip {
         transform: translateX(-100%) translateY(-0.5rem) translateZ(-1px);
         margin-left: 2rem;
-        margin-top: 1rem;
+        margin-top: 2rem;
     }
 
     &.selected {
         pointer-events: all;
         opacity: 1;
         transform: translateY(0);
+        cursor: default;
         
         &.flip {
             transform: translateX(-100%) translateY(0);
@@ -264,6 +265,7 @@
 
     >* {
         padding: 0.5rem 0;
+        cursor: pointer;
     }
 }
 
@@ -346,14 +348,13 @@
     .stadiaplus_libraryfilter-game {
         display: inline-flex;
         position: relative;
-        overflow: hidden;
+        overflow: visible;
 
         width: calc(25% - 1.5rem);
         height: 32vh;
         
         margin-left: 1.5rem;
         margin-bottom: 1.5rem;
-        border-radius: 0.5rem;
 
         box-shadow: 0 0.125rem 0.75rem rgba(0,0,0,0.32), 0 0.0625rem 0.375rem rgba(0,0,0,0.18);
 
@@ -367,6 +368,12 @@
 
         &.hidden {
             opacity: 0.5;
+        }
+
+        >div:not(.more-icon),
+        >div > picture {
+            border-radius: 0.5rem;
+            overflow: hidden;
         }
 
         .tile-background {

--- a/src/models/LibraryGame.ts
+++ b/src/models/LibraryGame.ts
@@ -85,12 +85,13 @@ export class LibraryGame {
                             .text(Language.get('library-filter.get-shortcut')),
                     )
                     .event({
-                        click: () => {
+                        click: ( event) => {
                             window.open(
                                 `https://stadiaicons.web.app/${this.uuid}/?fullName=${encodeURIComponent(this.name)}`,
                                 '_blank',
                             );
                             element.class({ selected: false });
+                            event.stopPropagation();
                         },
                     }),
             )
@@ -110,7 +111,7 @@ export class LibraryGame {
                             .text(Language.get(this.visible ? 'library-filter.hide-game' : 'library-filter.show-game', { name: this.name })),
                     )
                     .event({
-                        click: () => {
+                        click: (event) => {
                             const self = document.getElementById(`${this.uuid}-hideoption`);
                             // Always true, but should exist to appease the linting gods
                             if (self !== null) {
@@ -133,6 +134,8 @@ export class LibraryGame {
                             void this.libraryFilter.saveGameData();
                             this.libraryFilter.updateVisibility();
                             element.class({ selected: false });
+
+                            event.stopPropagation();
                         },
                     }),
             );


### PR DESCRIPTION
Fixes the issue where the dropdown dialog inside each library item gets clipped by the outer parent.

*Note: I can't seem to find any way of stopping event propagation here, so it always opens up the main game popup whenever these are clicked.*